### PR TITLE
Added watchman to install script

### DIFF
--- a/mac/setup.sh
+++ b/mac/setup.sh
@@ -24,6 +24,7 @@ cli=(
     libsass
     ruby
     yarn
+    watchman
     homebrew/php/php70
     homebrew/php/composer
 )


### PR DESCRIPTION
OS X users need to have [watchman](https://facebook.github.io/watchman/) installed, otherwise React Native doesn't work.